### PR TITLE
Fix method naming typo in Memory configuration sample

### DIFF
--- a/src/Configure/Controllers/TestController.cs
+++ b/src/Configure/Controllers/TestController.cs
@@ -44,7 +44,7 @@ namespace Configure.Controllers
         [HttpPut("Change")]
         public Task ChangeText(string text)
         {
-            _memorySource.Chnage(text);
+            _memorySource.Change(text);
             return Task.CompletedTask;
         }
     }

--- a/src/Configure/MemoryProvider.cs
+++ b/src/Configure/MemoryProvider.cs
@@ -16,7 +16,7 @@ namespace Configure
             return Data.GetEnumerator();
         }
 
-        internal void Chnage(string text)
+        internal void Change(string text)
         {
             Data["TestOption:Text"] = text;
             OnReload();

--- a/src/Configure/MemorySource.cs
+++ b/src/Configure/MemorySource.cs
@@ -10,9 +10,9 @@ namespace Configure
             return _provider;
         }
 
-        internal void Chnage(string text)
+        internal void Change(string text)
         {
-            _provider.Chnage(text);
+            _provider.Change(text);
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix spelling error from `Chnage` to `Change` in Configure sample

## Testing
- `dotnet build src/Configure/Configure.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840f0e010b48331ae8577e9e80c84af