### PR TITLE
Add .NET OpenTelemetry demo with Redis, PostgreSQL, and Jaeger

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: otel-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: otel
+      POSTGRES_PASSWORD: otel
+      POSTGRES_DB: otel
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    container_name: otel-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.54
+    container_name: otel-jaeger
+    restart: unless-stopped
+    environment:
+      COLLECTOR_ZIPKIN_HOST_PORT: ":9411"
+    command:
+      - "--collector.otlp.enabled=true"
+    ports:
+      - "16686:16686"
+      - "6831:6831/udp"
+      - "4317:4317"
+      - "4318:4318"
+
+volumes:
+  postgres-data:

--- a/docs/OpenTelemetryJaeger.md
+++ b/docs/OpenTelemetryJaeger.md
@@ -1,0 +1,49 @@
+# C# OpenTelemetry + Jaeger 範例
+
+這個範例示範如何使用 .NET 10 控制台應用程式透過 OpenTelemetry 收集下列操作的追蹤資訊，並送到 Jaeger 檢視：
+
+- 透過 `HttpClient` 呼叫 `https://www.google.com/`。
+- 使用 `StackExchange.Redis` 存取 Redis。
+- 使用 `Npgsql` 存取 PostgreSQL。
+
+## 專案位置
+
+應用程式原始碼位於 [`src/OpenTelemetryDemo`](../src/OpenTelemetryDemo)。
+
+## 快速開始
+
+1. 啟動 Redis、PostgreSQL 與 Jaeger：
+
+   ```bash
+   docker compose up -d
+   ```
+
+2. （可選）設定連線字串與 Jaeger 代理主機位置。以下為預設值，未設定時會直接使用：
+
+   ```bash
+   export Redis__ConnectionString="localhost:6379"
+   export Postgres__ConnectionString="Host=localhost;Username=otel;Password=otel;Database=otel"
+   export Jaeger__Host="localhost"
+   export Jaeger__Port=6831
+   ```
+
+3. 執行範例應用程式：
+
+   ```bash
+   dotnet run --project src/OpenTelemetryDemo/OpenTelemetryDemo.csproj
+   ```
+
+4. 開啟 Jaeger 介面 `http://localhost:16686`，選取服務名稱 `OpenTelemetryDemo` 後即可看到 `HttpClient`、Redis 與 PostgreSQL 的追蹤資料。
+
+## 範例程式重點
+
+- `Program.cs` 透過 `AddOpenTelemetry()` 註冊 `HttpClient`、Redis 與 Npgsql 的自動化儀表收集，並設定 Jaeger 匯出器。
+- `TelemetryWorker` 在應用程式啟動時依序對 Google、PostgreSQL 與 Redis 發出請求，讓上述儀表產生範例追蹤資料。
+
+## 清除資源
+
+完成後可停止並移除容器：
+
+```bash
+docker compose down
+```

--- a/src/OpenTelemetryDemo/OpenTelemetryDemo.csproj
+++ b/src/OpenTelemetryDemo/OpenTelemetryDemo.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Npgsql" Version="1.0.0-rc9.12" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.12" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
+  </ItemGroup>
+
+</Project>

--- a/src/OpenTelemetryDemo/Program.cs
+++ b/src/OpenTelemetryDemo/Program.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using StackExchange.Redis;
+
+var builder = Host.CreateDefaultBuilder(args);
+
+builder.ConfigureServices((context, services) =>
+{
+    var configuration = context.Configuration;
+
+    var redisConnectionString = configuration.GetValue<string>("Redis:ConnectionString") ?? "localhost:6379";
+    var postgresConnectionString = configuration.GetValue<string>("Postgres:ConnectionString") ??
+        "Host=localhost;Username=otel;Password=otel;Database=otel";
+    var jaegerHost = configuration.GetValue<string>("Jaeger:Host") ?? "localhost";
+    var jaegerPort = configuration.GetValue<int?>("Jaeger:Port") ?? 6831;
+
+    var redisConnection = new Lazy<ConnectionMultiplexer>(() => ConnectionMultiplexer.Connect(redisConnectionString));
+
+    services.AddSingleton(sp => redisConnection.Value);
+
+    services.AddSingleton(new TelemetryOptions
+    {
+        RedisConnectionString = redisConnectionString,
+        PostgresConnectionString = postgresConnectionString,
+        JaegerHost = jaegerHost,
+        JaegerPort = jaegerPort
+    });
+
+    services.AddHttpClient(TelemetryWorker.GoogleClientName, client =>
+    {
+        client.BaseAddress = new Uri("https://www.google.com/");
+    });
+
+    services.AddHostedService<TelemetryWorker>();
+
+    services.AddOpenTelemetry()
+        .WithTracing(tracerBuilder =>
+        {
+            tracerBuilder
+                .AddSource(TelemetryWorker.ActivitySourceName)
+                .SetResourceBuilder(ResourceBuilder
+                    .CreateDefault()
+                    .AddService("OpenTelemetryDemo", serviceVersion: "1.0.0"))
+                .AddHttpClientInstrumentation()
+                .AddRedisInstrumentation(options =>
+                {
+                    options.FlushInterval = TimeSpan.FromSeconds(1);
+                    options.SetConnectionMultiplexerFactory(() => redisConnection.Value);
+                })
+                .AddNpgsql()
+                .AddJaegerExporter(options =>
+                {
+                    options.AgentHost = jaegerHost;
+                    options.AgentPort = jaegerPort;
+                });
+        });
+});
+
+await builder.RunConsoleAsync();
+
+internal sealed record TelemetryOptions
+{
+    public string RedisConnectionString { get; init; } = string.Empty;
+    public string PostgresConnectionString { get; init; } = string.Empty;
+    public string JaegerHost { get; init; } = string.Empty;
+    public int JaegerPort { get; init; }
+}

--- a/src/OpenTelemetryDemo/TelemetryWorker.cs
+++ b/src/OpenTelemetryDemo/TelemetryWorker.cs
@@ -1,0 +1,136 @@
+using System.Diagnostics;
+using System.Net.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using StackExchange.Redis;
+
+internal sealed class TelemetryWorker : IHostedService
+{
+    internal const string ActivitySourceName = "OpenTelemetryDemo.TelemetryWorker";
+    internal const string GoogleClientName = "google";
+
+    private static readonly ActivitySource ActivitySource = new(ActivitySourceName);
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<TelemetryWorker> _logger;
+    private readonly TelemetryOptions _options;
+    private readonly IConnectionMultiplexer _redisConnection;
+    private readonly IHostApplicationLifetime _applicationLifetime;
+
+    public TelemetryWorker(
+        IHttpClientFactory httpClientFactory,
+        ILogger<TelemetryWorker> logger,
+        TelemetryOptions options,
+        IConnectionMultiplexer redisConnection,
+        IHostApplicationLifetime applicationLifetime)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _options = options;
+        _redisConnection = redisConnection;
+        _applicationLifetime = applicationLifetime;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Starting telemetry operations");
+
+        using var activity = ActivitySource.StartActivity("Demo run", ActivityKind.Internal);
+
+        if (activity is not null)
+        {
+            activity.SetTag("redis.connection", _options.RedisConnectionString);
+            activity.SetTag("postgres.connection", _options.PostgresConnectionString);
+            activity.SetTag("jaeger.host", _options.JaegerHost);
+            activity.SetTag("jaeger.port", _options.JaegerPort);
+        }
+
+        try
+        {
+            await ExecuteHttpRequestAsync(cancellationToken);
+            await ExecutePostgresCommandsAsync(cancellationToken);
+            await ExecuteRedisCommandsAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            _logger.LogError(ex, "An error occurred while running telemetry operations");
+        }
+        finally
+        {
+            _applicationLifetime.StopApplication();
+            _logger.LogInformation("Telemetry operations completed");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Telemetry worker is stopping");
+        return Task.CompletedTask;
+    }
+
+    private async Task ExecuteHttpRequestAsync(CancellationToken cancellationToken)
+    {
+        using var activity = ActivitySource.StartActivity("HTTP GET google", ActivityKind.Client);
+
+        var client = _httpClientFactory.CreateClient(GoogleClientName);
+
+        _logger.LogInformation("Sending request to {Url}", client.BaseAddress);
+        using var response = await client.GetAsync(string.Empty, cancellationToken);
+        var contentLength = response.Content.Headers.ContentLength;
+
+        activity?.SetTag("http.status_code", (int)response.StatusCode);
+        activity?.SetTag("http.response_content_length", contentLength);
+
+        _logger.LogInformation("Received {StatusCode} from {Url}", response.StatusCode, client.BaseAddress);
+    }
+
+    private async Task ExecutePostgresCommandsAsync(CancellationToken cancellationToken)
+    {
+        using var activity = ActivitySource.StartActivity("PostgreSQL commands", ActivityKind.Client);
+
+        await using var connection = new NpgsqlConnection(_options.PostgresConnectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        await using var createTable = new NpgsqlCommand(
+            "CREATE TABLE IF NOT EXISTS telemetry_demo (id SERIAL PRIMARY KEY, created_at TIMESTAMPTZ NOT NULL)",
+            connection);
+        await createTable.ExecuteNonQueryAsync(cancellationToken);
+
+        await using var insertCommand = new NpgsqlCommand(
+            "INSERT INTO telemetry_demo(created_at) VALUES (@created_at) RETURNING id",
+            connection);
+        insertCommand.Parameters.AddWithValue("created_at", DateTime.UtcNow);
+        var insertedId = (int)(await insertCommand.ExecuteScalarAsync(cancellationToken) ?? 0);
+
+        await using var queryCommand = new NpgsqlCommand(
+            "SELECT created_at FROM telemetry_demo WHERE id = @id",
+            connection);
+        queryCommand.Parameters.AddWithValue("id", insertedId);
+        var queriedValue = await queryCommand.ExecuteScalarAsync(cancellationToken);
+
+        activity?.SetTag("db.last_insert_id", insertedId);
+        activity?.SetTag("db.queried_value", queriedValue);
+
+        _logger.LogInformation("Inserted row {Id} at {Timestamp}", insertedId, queriedValue);
+    }
+
+    private async Task ExecuteRedisCommandsAsync(CancellationToken cancellationToken)
+    {
+        using var activity = ActivitySource.StartActivity("Redis commands", ActivityKind.Client);
+
+        var database = _redisConnection.GetDatabase();
+        var cacheKey = "otel-demo:timestamp";
+        var cacheValue = DateTimeOffset.UtcNow.ToString("O");
+
+        _logger.LogInformation("Writing value to Redis at {Key}", cacheKey);
+        await database.StringSetAsync(cacheKey, cacheValue);
+
+        var storedValue = await database.StringGetAsync(cacheKey);
+        activity?.SetTag("redis.key", cacheKey);
+        activity?.SetTag("redis.value", storedValue);
+
+        _logger.LogInformation("Read value {Value} from Redis at {Key}", storedValue, cacheKey);
+    }
+}


### PR DESCRIPTION
## Summary
- add a .NET 10 console app configured with OpenTelemetry tracing for HTTP, Redis, and PostgreSQL calls
- implement a worker that exercises Google, Redis, and PostgreSQL to generate sample spans
- provide docker compose services and documentation for Jaeger-based tracing demo

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68f8462ab8bc8331bc2a45a8690a62cc